### PR TITLE
ambiguous multimapped_mode

### DIFF
--- a/python2/HTSeq/scripts/count.py
+++ b/python2/HTSeq/scripts/count.py
@@ -439,9 +439,10 @@ def main():
 
     pa.add_argument(
             "--nonunique", dest="nonunique", type=str,
-            choices=("none", "all"), default="none",
-            help="Whether to score reads that are not uniquely aligned " +
-            "or ambiguously assigned to features")
+            choices=("none", "all", "fraction", "random"), default="none",
+            help="Whether and how to score reads that are not uniquely aligned " +
+            "or ambiguously assigned to features " +
+            "(choices: none, all, fraction, random; default: none)")
 
     pa.add_argument(
             "--secondary-alignments", dest="secondary_alignments", type=str,

--- a/python2/HTSeq/scripts/count.py
+++ b/python2/HTSeq/scripts/count.py
@@ -4,6 +4,7 @@ import itertools
 import warnings
 import traceback
 import os.path
+import random
 
 import HTSeq
 
@@ -298,6 +299,12 @@ def count_reads_in_features(sam_filenames, gff_filename,
                         elif multimapped_mode == 'all':
                             for fsi in list(fs):
                                 counts[fsi] += 1
+                        elif multimapped_mode == 'fraction':
+                            for fsi in list(fs):
+                                counts[fsi] += 1.0 / len(fs)
+                        elif multimapped_mode == 'random':
+                            fsi = random.choice(fs)
+                            counts[fsi] += 1
                         else:
                             sys.exit("Illegal multimap mode.")
 

--- a/python3/HTSeq/scripts/count.py
+++ b/python3/HTSeq/scripts/count.py
@@ -280,7 +280,7 @@ def count_reads_single_file(
                             counts[fsi] += 1
                     elif multimapped_mode == 'fraction':
                         for fsi in list(fs):
-                            counts[fsi] += 1 / len(fs)
+                            counts[fsi] += 1.0 / len(fs)
                     elif multimapped_mode == 'random':
                         fsi = random.choice(fs)
                         counts[fsi] += 1

--- a/python3/HTSeq/scripts/count.py
+++ b/python3/HTSeq/scripts/count.py
@@ -7,6 +7,7 @@ import traceback
 import os.path
 import multiprocessing
 import pysam
+import random
 
 import HTSeq
 
@@ -277,6 +278,12 @@ def count_reads_single_file(
                     elif multimapped_mode == 'all':
                         for fsi in list(fs):
                             counts[fsi] += 1
+                    elif multimapped_mode == 'fraction':
+                        for fsi in list(fs):
+                            counts[fsi] += 1 / len(fs)
+                    elif multimapped_mode == 'random':
+                        fsi = random.choice(fs)
+                        counts[fsi] += 1
                     else:
                         sys.exit("Illegal multimap mode.")
 

--- a/python3/HTSeq/scripts/count.py
+++ b/python3/HTSeq/scripts/count.py
@@ -569,9 +569,10 @@ def main():
 
     pa.add_argument(
             "--nonunique", dest="nonunique", type=str,
-            choices=("none", "all"), default="none",
-            help="Whether to score reads that are not uniquely aligned " +
-            "or ambiguously assigned to features")
+            choices=("none", "all", "fraction", "random"), default="none",
+            help="Whether and how to score reads that are not uniquely aligned " +
+            "or ambiguously assigned to features " +
+            "(choices: none, all, fraction, random; default: none)")
 
     pa.add_argument(
             "--secondary-alignments", dest="secondary_alignments", type=str,

--- a/python3/doc/count.rst
+++ b/python3/doc/count.rst
@@ -57,7 +57,7 @@ the ``--nonunique`` option:
   example, if the read overlaps with 3 features, it will be counted 1/3 to each of them.
 
 * ``--nonunique random``: the read (or read pair) is counted as ``ambiguous``
-  and is also counted uniformly at random to ``one of` the features to which it was 
+  and is also counted uniformly at random to ``one of`` the features to which it was 
   assigned.
 
 Notice that when using ``--nonunique all`` the sum of all counts will not

--- a/python3/doc/count.rst
+++ b/python3/doc/count.rst
@@ -52,9 +52,19 @@ the ``--nonunique`` option:
   read (or read pair) aligns to more than one location in the reference, it is
   scored as ``alignment_not_unique`` and also separately for each location.
 
+* ``--nonunique fraction``: the read (or read pair) is counted as ``ambiguous``
+  and is also counted fractionally in all features to which it was assigned. For 
+  example, if the read overlaps with 3 features, it will be counted 1/3 to each of them.
+
+* ``--nonunique random``: the read (or read pair) is counted as ``ambiguous``
+  and is also counted uniformly at random to ``one of` the features to which it was 
+  assigned.
+
 Notice that when using ``--nonunique all`` the sum of all counts will not
 be equal to the number of reads (or read pairs), because those with multiple
-alignments or overlaps get scored multiple times.
+alignments or overlaps get scored multiple times. By contrast, with 
+``--nonunique fraction`` or ``--nonunique random``, the sum of all counts 
+will be equal to the number of reads (or read pairs).
 
 The following figure illustrates the effect of these three modes and the
 ``--nonunique`` option:


### PR DESCRIPTION
Added two options to `multimapped_mode` / --nonunique

* option fraction assigns a multimapped read that overlaps to `features` to *all* of them with *fractional count* of 1/ len(features)
* option random assigns a multimapped read that overlaps to `features` to *one* at random with uniform probability 1/ len(features)